### PR TITLE
Standardize version

### DIFF
--- a/pfl-asm/pom.xml
+++ b/pfl-asm/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl</artifactId>
-        <version>4.0.1-b004-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pfl-asm</artifactId>

--- a/pfl-basic-tools/pom.xml
+++ b/pfl-basic-tools/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl</artifactId>
-        <version>4.0.1-b004-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pfl-basic-tools</artifactId>

--- a/pfl-basic/pom.xml
+++ b/pfl-basic/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl</artifactId>
-        <version>4.0.1-b004-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pfl-basic</artifactId>

--- a/pfl-dynamic/pom.xml
+++ b/pfl-dynamic/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl</artifactId>
-        <version>4.0.1-b004-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pfl-dynamic</artifactId>

--- a/pfl-test/pom.xml
+++ b/pfl-test/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl</artifactId>
-        <version>4.0.1-b004-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pfl-test</artifactId>

--- a/pfl-tf-tools/pom.xml
+++ b/pfl-tf-tools/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl</artifactId>
-        <version>4.0.1-b004-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pfl-tf-tools</artifactId>

--- a/pfl-tf/pom.xml
+++ b/pfl-tf/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl</artifactId>
-        <version>4.0.1-b004-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pfl-tf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.glassfish.pfl</groupId>
     <artifactId>pfl</artifactId>
-    <version>4.0.1-b004-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     
     <name>Eclipse ORB</name>


### PR DESCRIPTION
Version number currently also has the build number in it,  removed it to keep it consistent with versioning convention as being followed in other eclipse-ee4j projects.
