### PR TITLE
Use JDK8 functions and deprecate duplications

### DIFF
--- a/pfl-basic/src/main/java/org/glassfish/pfl/basic/algorithm/Algorithms.java
+++ b/pfl-basic/src/main/java/org/glassfish/pfl/basic/algorithm/Algorithms.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2007, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -11,7 +12,6 @@
 package org.glassfish.pfl.basic.algorithm ;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -33,12 +33,15 @@ import org.glassfish.pfl.basic.func.UnaryPredicate;
 public final class Algorithms {
     private Algorithms() {}
     
+    /**
+     * Converts an array of objects into a list
+     * @param <T> type of objects
+     * @param arg the array of objects
+     * @return list of objects
+     * @deprecated replaced by {@link Arrays#asList(java.lang.Object...)}
+     */
     public static <T> List<T> list( T... arg ) {
-        List<T> result = new ArrayList<T>() ;
-        for (T obj : arg) {
-            result.add( obj ) ;
-        }
-        return result ;
+        return Arrays.asList(arg) ;
     }
 
     public static <S,T> Pair<S,T> pair( S first, T second ) {

--- a/pfl-basic/src/main/java/org/glassfish/pfl/basic/algorithm/ObjectUtility.java
+++ b/pfl-basic/src/main/java/org/glassfish/pfl/basic/algorithm/ObjectUtility.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2002, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -25,6 +26,7 @@ import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Enumeration;
@@ -372,9 +374,7 @@ public final class ObjectUtility {
                     fields = getDeclaredFields(current);
                 }
 
-                for (Field fld : fields) {
-                    allFields.add(fld);
-                }
+                allFields.addAll(Arrays.asList(fields));
 
                 current = current.getSuperclass();
             }

--- a/pfl-basic/src/main/java/org/glassfish/pfl/basic/contain/Pair.java
+++ b/pfl-basic/src/main/java/org/glassfish/pfl/basic/contain/Pair.java
@@ -10,7 +10,7 @@
 
 package org.glassfish.pfl.basic.contain ;
 
-/** A utilitiy class representing a generic types Pair of elements.
+/** A utility class representing a generic types Pair of elements.
  * Useful for simple data structures, returning multiple values, etc.
  * {@code Pair<Object,Object>} is similar to a cons cell.
  */

--- a/pfl-basic/src/main/java/org/glassfish/pfl/basic/fsm/Guard.java
+++ b/pfl-basic/src/main/java/org/glassfish/pfl/basic/fsm/Guard.java
@@ -21,7 +21,7 @@ public interface Guard {
     enum Result { ENABLED, DISABLED, DEFERRED } ;
 
     /** Called by the state engine to determine whether a
-    * transition is enabled, defered, or disabled.
+    * transition is enabled, deferred, or disabled.
     * The result is interpreted as follows:
     * <ul>
     * <li>ENABLED if the transition is ready to proceed
@@ -30,7 +30,7 @@ public interface Guard {
     * is to be deferred.  This means that the input will not be 
     * acted upon, but rather it will be saved for later execution.
     * Typically this is implemented using a CondVar wait, and the
-    * blocked thread represents the defered input.  The defered
+    * blocked thread represents the deferred input.  The deferred
     * input is retried when the thread runs again.
     * </ul>
     *

--- a/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/BinaryFunction.java
+++ b/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/BinaryFunction.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,6 +11,17 @@
 
 package org.glassfish.pfl.basic.func ;
 
-public interface BinaryFunction<S,T,R> {
-    R evaluate( S arg1, T arg2 ) ;
+import java.util.function.BiFunction;
+
+/**
+ * @deprecated replaced in JDK8 by {@link BiFunction}
+ */
+@Deprecated
+public interface BinaryFunction<S,T,R> extends BiFunction<S,T,R> {
+    R evaluate( S arg1, T arg2 );
+    
+    @Override
+    default R apply(S arg1, T arg2) {
+        return evaluate(arg1, arg2);
+    }
 }

--- a/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/BinaryPredicate.java
+++ b/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/BinaryPredicate.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,7 +11,18 @@
 
 package org.glassfish.pfl.basic.func ;
 
-public interface BinaryPredicate<S,T> {
+import java.util.function.BiPredicate;
+
+/**
+ * @deprecated replaced in JDK8 by {@link BiPredicate}
+ */
+@Deprecated
+public interface BinaryPredicate<S,T> extends BiPredicate<S, T>{
     boolean evaluate( S arg1, T arg2 ) ;
+    
+    @Override
+    default boolean test(S arg1, T arg2) {
+        return evaluate(arg1, arg2);
+    }
 }
 

--- a/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/BinaryVoidFunction.java
+++ b/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/BinaryVoidFunction.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,6 +11,17 @@
 
 package org.glassfish.pfl.basic.func ;
 
-public interface BinaryVoidFunction<S,T> {
+import java.util.function.BiConsumer;
+
+/**
+ * @deprecated replaced by {@link BiConsumer}
+ */
+@Deprecated
+public interface BinaryVoidFunction<S,T> extends BiConsumer<S, T> {
     void evaluate( S arg1, T arg2 ) ;
+    
+    @Override
+    default void accept(S arg1, T arg2) {
+        evaluate(arg1, arg2);
+    }
 }

--- a/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/NullaryFunction.java
+++ b/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/NullaryFunction.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2004, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,6 +11,11 @@
 
 package org.glassfish.pfl.basic.func ;
 
+/**
+ * A function that takes no arguments and returns a result.
+ * @deprecated replaced by {@link java.util.function.Supplier}
+ */
+@Deprecated
 public interface NullaryFunction<T> {
     public T evaluate() ;
 

--- a/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/UnaryFunction.java
+++ b/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/UnaryFunction.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,7 +11,19 @@
 
 package org.glassfish.pfl.basic.func ;
 
-public interface UnaryFunction<T,R> {
+import java.util.function.Function;
+
+/**
+ * Represents a functions that takes one argument and returns a result
+ * @deprecated replaced in JDK8 by {@link java.util.function.Function}
+ */
+@Deprecated
+public interface UnaryFunction<T,R> extends Function<T,R> {
     R evaluate( T arg ) ;
+    
+    @Override
+    default R apply(T t) {
+        return evaluate(t);
+    }
 }
 

--- a/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/UnaryPredicate.java
+++ b/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/UnaryPredicate.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,7 +11,18 @@
 
 package org.glassfish.pfl.basic.func ;
 
-public interface UnaryPredicate<T> {
+import java.util.function.Predicate;
+
+/**
+ * @deprecated replaced by {@link Predicate}
+ */
+@Deprecated
+public interface UnaryPredicate<T> extends Predicate<T>{
     boolean evaluate( T arg ) ;
+    
+    @Override
+    default boolean test(T t) {
+        return evaluate(t);
+    }
 }
 

--- a/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/UnaryVoidFunction.java
+++ b/pfl-basic/src/main/java/org/glassfish/pfl/basic/func/UnaryVoidFunction.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,6 +11,17 @@
 
 package org.glassfish.pfl.basic.func ;
 
-public interface UnaryVoidFunction<T> {
+import java.util.function.Consumer;
+
+/**
+ * @deprecated replaced by {@link Consumer}
+ */
+@Deprecated
+public interface UnaryVoidFunction<T> extends Consumer<T> {
     void evaluate( T arg ) ;
+    
+    @Override
+    default void accept(T t) {
+        evaluate(t);
+    }
 }

--- a/pfl-basic/src/main/java/org/glassfish/pfl/basic/logex/OperationTracer.java
+++ b/pfl-basic/src/main/java/org/glassfish/pfl/basic/logex/OperationTracer.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -173,14 +174,18 @@ public class OperationTracer {
         final List<Element> elements = state.get() ;
         int count = 0 ;
         for (Element elem : elements) {
-            if (count == 0) {
-                sb.append( elem.getAsString() ) ;
-                sb.append( ':' ) ;
-            } else if (count == 1) {
-                sb.append( elem.getAsString() ) ;
-            } else {
-                sb.append( ',' ) ;
-                sb.append( elem.getAsString() ) ;
+            switch (count) {
+                case 0:
+                    sb.append( elem.getAsString() ) ;
+                    sb.append( ':' ) ;
+                    break;
+                case 1:
+                    sb.append( elem.getAsString() ) ;
+                    break;
+                default:
+                    sb.append( ',' ) ;
+                    sb.append( elem.getAsString() ) ;
+                    break;
             }
 
             count++ ;

--- a/pom.xml
+++ b/pom.xml
@@ -152,26 +152,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-toolchains-plugin</artifactId>
-                <version>1.1</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>toolchain</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <toolchains>
-                        <jdk>
-                            <version>${base.java.version}</version>
-                            <vendor>oracle</vendor>
-                        </jdk>
-                    </toolchains>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,26 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>1.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <toolchains>
+                        <jdk>
+                            <version>${base.java.version}</version>
+                            <vendor>oracle</vendor>
+                        </jdk>
+                    </toolchains>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>


### PR DESCRIPTION
Much of the functional coding is now part of the JDK, so PR makes the gmbal-pfl version deprectaed and extend the JDK8 versions.