### PR TITLE
Get ready for Jenkins release

### DIFF
--- a/bundles.xml
+++ b/bundles.xml
@@ -145,16 +145,6 @@
                 <directive type="Export-Package" name="test.export"/>
             </directive-list>
         </make-bundle>
-	<make-bundle 
-            bundlename="pfl-asm"
-            outfile="pfl-asm.jar"
-            outdir="${bundle.dir}"
-            version="${version}"
-            classpath="${bnd.classpath}">
-            <directive-list>
-		<directive type="Export-Package" name="asm.export"/>
-	    </directive-list>
-	</make-bundle>
     </target>
 
     <target name="-post-jar" depends="make-bundles"/>
@@ -176,10 +166,7 @@
     </macrodef>
 
     <target name="make-poms" depends="modules.init">
-	<make-pfl-pom artifactid="pfl-asm" 
-	    description="ASM version used in the ORB">
-	</make-pfl-pom>
-	<make-pfl-pom artifactid="pfl-basic" 
+	<make-pfl-pom artifactid="pfl-basic"
 	    description="Base library for functions, logex, fsm, etc.">
 	</make-pfl-pom>
 	<make-pfl-pom artifactid="pfl-basic-tools" 
@@ -194,10 +181,6 @@
 	<make-pfl-pom artifactid="pfl-dynamic" 
 	    description="Dynamic code generation library">
 	    <dep-list>
-		<dependency
-		    groupId="org.glassfish.pfl"
-		    artifactId="pfl-asm"
-		    version="${version}"/>
 		<dependency
 		    groupId="org.glassfish.pfl"
 		    artifactId="pfl-basic"
@@ -222,10 +205,6 @@
 	    <dep-list>
 		<dependency
 		    groupId="org.glassfish.pfl"
-		    artifactId="pfl-asm"
-		    version="${version}"/>
-		<dependency
-		    groupId="org.glassfish.pfl"
 		    artifactId="pfl-basic"
 		    version="${version}"/>
 	    </dep-list>
@@ -233,10 +212,6 @@
 	<make-pfl-pom artifactid="pfl-tf-tools" 
 	    description="Tracing facility library">
 	    <dep-list>
-		<dependency
-		    groupId="org.glassfish.pfl"
-		    artifactId="pfl-asm"
-		    version="${version}"/>
 		<dependency
 		    groupId="org.glassfish.pfl"
 		    artifactId="pfl-basic"
@@ -251,10 +226,7 @@
 		    version="${version}"/>
 	    </dep-list>
 	</make-pfl-pom>
-	<make-pfl-pom artifactid="pfl-asm" 
-	    description="Tracing facility build tools">
-	</make-pfl-pom>
-	<make-pfl-pom artifactid="pfl-source" 
+	<make-pfl-pom artifactid="pfl-source"
 	    description="All pfl source code">
 	</make-pfl-pom>
     </target>
@@ -280,7 +252,6 @@
         <attribute name="destination"/>
         <sequential>
             <echo message="Releasing modules with version ${version} to @{destination}"/>
-            <pfl-push-to-maven destination="@{destination}" module="pfl-asm"/>
             <pfl-push-to-maven destination="@{destination}" module="pfl-basic" />
             <pfl-push-to-maven destination="@{destination}" module="pfl-basic-tools"/>
             <pfl-push-to-maven destination="@{destination}" module="pfl-dynamic"/>
@@ -294,7 +265,6 @@
     <macrodef name="release-to-local-maven">
         <sequential>
             <echo message="Releasing modules with version ${version} to local repository"/>
-            <pfl-push-to-local-maven module="pfl-asm"/>
             <pfl-push-to-local-maven module="pfl-basic"/>
             <pfl-push-to-local-maven module="pfl-basic-tools"/>
             <pfl-push-to-local-maven module="pfl-dynamic"/>

--- a/pfl-dynamic/pom.xml
+++ b/pfl-dynamic/pom.xml
@@ -26,11 +26,6 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>pfl-asm</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>pfl-basic</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pfl-test/pom.xml
+++ b/pfl-test/pom.xml
@@ -51,12 +51,6 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>pfl-asm</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>pfl-dynamic</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/pfl-tf-tools/pom.xml
+++ b/pfl-tf-tools/pom.xml
@@ -35,11 +35,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>pfl-asm</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-commons</artifactId>
             <version>7.3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,9 @@
 
         <!-- A directory for unit tests, allowing testing against MR classes. -->
         <combined.classes.dir>${project.build.directory}/combined-classes</combined.classes.dir>
+
+        <!-- a prefix for toolchains IDs, allowing builds to happen in different environments -->
+        <toolchains.id.prefix/>
     </properties>
     
     <modules>
@@ -164,7 +167,7 @@
                 <configuration>
                     <toolchains>
                         <jdk>
-                            <version>JavaSE-${base.java.version}</version>
+                            <version>${toolchains.id.prefix}${base.java.version}</version>
                         </jdk>
                     </toolchains>
                 </configuration>
@@ -189,7 +192,7 @@
                         <configuration>
                             <release>9</release>
                             <jdkToolchain>
-                                <version>JavaSE-9</version>
+                                <version>${toolchains.id.prefix}9</version>
                             </jdkToolchain>
                             <compileSourceRoots>
                                 <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
@@ -207,7 +210,7 @@
                         <configuration>
                             <release>11</release>
                             <jdkToolchain>
-                                <version>JavaSE-11</version>
+                                <version>${toolchains.id.prefix}11</version>
                             </jdkToolchain>
                             <compileSourceRoots>
                                 <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
                 <configuration>
                     <toolchains>
                         <jdk>
-                            <version>${base.java.version}</version>
+                            <version>JavaSE-${base.java.version}</version>
                         </jdk>
                     </toolchains>
                 </configuration>
@@ -189,7 +189,7 @@
                         <configuration>
                             <release>9</release>
                             <jdkToolchain>
-                                <version>9</version>
+                                <version>JavaSE-9</version>
                             </jdkToolchain>
                             <compileSourceRoots>
                                 <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
@@ -207,7 +207,7 @@
                         <configuration>
                             <release>11</release>
                             <jdkToolchain>
-                                <version>11</version>
+                                <version>JavaSE-11</version>
                             </jdkToolchain>
                             <compileSourceRoots>
                                 <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>


### PR DESCRIPTION
There are two changes in this PR:

1. There were a number of leftover references to pfl-asm that needed to be removed
2. The Eclipse Jenkins process now supplies a built-in toolchain and the references needed to adopt its style