### PR TITLE
Upgrade parent, remove toolchains ID property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.6</version>
     </parent>
 
     <groupId>org.glassfish.pfl</groupId>
@@ -82,9 +82,6 @@
 
         <!-- A directory for unit tests, allowing testing against MR classes. -->
         <combined.classes.dir>${project.build.directory}/combined-classes</combined.classes.dir>
-
-        <!-- a prefix for toolchains IDs, allowing builds to happen in different environments -->
-        <toolchains.id.prefix/>
     </properties>
     
     <modules>
@@ -167,7 +164,7 @@
                 <configuration>
                     <toolchains>
                         <jdk>
-                            <version>${toolchains.id.prefix}${base.java.version}</version>
+                            <version>${base.java.version}</version>
                         </jdk>
                     </toolchains>
                 </configuration>
@@ -192,7 +189,7 @@
                         <configuration>
                             <release>9</release>
                             <jdkToolchain>
-                                <version>${toolchains.id.prefix}9</version>
+                                <version>9</version>
                             </jdkToolchain>
                             <compileSourceRoots>
                                 <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
@@ -210,7 +207,7 @@
                         <configuration>
                             <release>11</release>
                             <jdkToolchain>
-                                <version>${toolchains.id.prefix}11</version>
+                                <version>11</version>
                             </jdkToolchain>
                             <compileSourceRoots>
                                 <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>


### PR DESCRIPTION
Removed attempt to workaround eclipse toolchains issue, since it was fix in their infra

Upgrade to latest parent POM to get correct distribution URL