### PR TITLE
Changed version number to 5.0.0-SNAPSHOT 

### DIFF
--- a/pfl-basic-tools/pom.xml
+++ b/pfl-basic-tools/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl</artifactId>
-        <version>4.1.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pfl-basic-tools</artifactId>

--- a/pfl-basic/pom.xml
+++ b/pfl-basic/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl</artifactId>
-        <version>4.1.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pfl-basic</artifactId>

--- a/pfl-dynamic/pom.xml
+++ b/pfl-dynamic/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl</artifactId>
-        <version>4.1.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pfl-dynamic</artifactId>

--- a/pfl-test/pom.xml
+++ b/pfl-test/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl</artifactId>
-        <version>4.1.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pfl-test</artifactId>

--- a/pfl-tf-tools/pom.xml
+++ b/pfl-tf-tools/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl</artifactId>
-        <version>4.1.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pfl-tf-tools</artifactId>

--- a/pfl-tf/pom.xml
+++ b/pfl-tf/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl</artifactId>
-        <version>4.1.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pfl-tf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.glassfish.pfl</groupId>
     <artifactId>pfl</artifactId>
-    <version>4.1.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     
     <name>Eclipse ORB</name>


### PR DESCRIPTION
Also in  40e93a6 @smillidge set Jenkins to use JDK11, but pom.xml remained on JDK 8.
It doesn't work well with the Unsafe class. I will continue with the fix in another PR; The version should probably change to 5.0.0-SNAPSHOT then.

EDIT 14. December 2022:
I'm looking at sources and I have a question: do we have a plan what we will do next? I think for GlassFish8 we should use Java Modules - that makes the current Class.defineClass usages impossible (they are already deprecated), we have to use MethodHandle as I did in ClassGenerator in GlassFish. That can lead to bit unpredictable hurdles we would need to resolve (tests will show, in GF I had to change some names of generated packages to comply with rules).

Then to get this PR to the track - what if I would for now revert the JDK to 8 (just in pom), but I would change the version in master directly to 5.0.0-SNAPSHOT? If we would need patches, we can create new branches for them.

Then in future PRs we would make other changes (delete deprecated methods? Then fix the glassfish-corba-orb to use another impl ... or ask for user's provider of the generator? Not sure yet).

![image](https://user-images.githubusercontent.com/302904/207586348-4db72b77-3fff-4572-af7c-4914dc8746c7.png)

I'm asking for the answer also @hs536 , @smillidge and @kaido207 too as they recently committed to this repo. If you agree, please approve this PR, if you disagree, reject it.
