### PR TITLE
Fix to re-enable ORB Method Trace

### DIFF
--- a/pfl-dynamic/src/main/java/org/glassfish/pfl/dynamic/codegen/impl/ByteCodeUtility.java
+++ b/pfl-dynamic/src/main/java/org/glassfish/pfl/dynamic/codegen/impl/ByteCodeUtility.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 Payara Services Ltd.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -491,7 +492,7 @@ public final class ByteCodeUtility {
 	String name, Signature sig ) {
 
 	mv.visitMethodInsn( INVOKESTATIC, ASMUtil.bcName(type), name, 
-	    sig.signature() ) ;
+	    sig.signature(), false ) ;
     }
 
     /** Emit the appropriate non-static INVOKE instruction as follows:
@@ -529,7 +530,7 @@ public final class ByteCodeUtility {
 
 	String typeName = ASMUtil.bcName(mcinfo.thisType()) ;
 
-	mv.visitMethodInsn( opcode, typeName, name, sigString ) ;
+	mv.visitMethodInsn( opcode, typeName, name, sigString, mcinfo.isInterface() ) ;
     }
 
     /** Emit the INVOKESPECIAL instruction for calling a constructor
@@ -540,7 +541,7 @@ public final class ByteCodeUtility {
 
 	String typeName = ASMUtil.bcName(type) ;
 	mv.visitMethodInsn( INVOKESPECIAL, typeName, 
-	    CodeGeneratorUtil.CONSTRUCTOR_METHOD_NAME, sig.signature()) ;
+	    CodeGeneratorUtil.CONSTRUCTOR_METHOD_NAME, sig.signature(), false) ;
     }
 
     /** Emit the INVOKESPECIAL instruction for calling a method
@@ -551,7 +552,7 @@ public final class ByteCodeUtility {
 
 	String typeName = ASMUtil.bcName(type) ;
 	mv.visitMethodInsn( INVOKESPECIAL, typeName, 
-	    name, sig.signature() ) ;
+	    name, sig.signature(), false ) ;
     }
 
     public void emitThrow() {

--- a/pfl-tf-tools/src/main/java/org/glassfish/pfl/tf/tools/enhancer/ClassEnhancer.java
+++ b/pfl-tf-tools/src/main/java/org/glassfish/pfl/tf/tools/enhancer/ClassEnhancer.java
@@ -134,7 +134,7 @@ public class ClassEnhancer extends TFEnhanceAdapter {
 
             mv.visitMethodInsn( Opcodes.INVOKEINTERFACE,
                 EnhancedClassData.MM_NAME, "info",
-                "([Ljava/lang/Object;II)V") ;
+                "([Ljava/lang/Object;II)V", true) ;
 
             mv.visitLabel( jumpLabel ) ;
 
@@ -153,7 +153,7 @@ public class ClassEnhancer extends TFEnhanceAdapter {
 
         @Override
         public void visitMethodInsn( int opcode, String owner,
-            String name, String desc ) {
+            String name, String desc, boolean isInterface ) {
             info( 2, "InfoMethodCallRewriter: visitMethodInsn: " + owner
                 + "." + name + desc ) ;
 
@@ -180,9 +180,9 @@ public class ClassEnhancer extends TFEnhanceAdapter {
 
                 String newDesc = util.augmentInfoMethodDescriptor(desc) ;
 
-                mv.visitMethodInsn(opcode, owner, name, newDesc );
+                mv.visitMethodInsn(opcode, owner, name, newDesc, isInterface );
             } else {
-                mv.visitMethodInsn(opcode, owner, name, desc );
+                mv.visitMethodInsn(opcode, owner, name, desc, isInterface );
             }
         }
     }
@@ -199,7 +199,7 @@ public class ClassEnhancer extends TFEnhanceAdapter {
 
         @Override
         public void visitMethodInsn( int opcode, String owner,
-            String name, String desc ) {
+            String name, String desc, boolean isInterface ) {
             info( 2, "NormalMethodChecker: visitMethodInsn: " + owner
                 + "." + name + desc ) ;
 
@@ -217,7 +217,7 @@ public class ClassEnhancer extends TFEnhanceAdapter {
                     + " illegal call to an @InfoMethod method" ) ;
             }
 
-            mv.visitMethodInsn( opcode, owner, name, desc ) ;
+            mv.visitMethodInsn( opcode, owner, name, desc, isInterface ) ;
         }
     }
 

--- a/pfl-tf-tools/src/main/java/org/glassfish/pfl/tf/tools/enhancer/ClassEnhancer.java
+++ b/pfl-tf-tools/src/main/java/org/glassfish/pfl/tf/tools/enhancer/ClassEnhancer.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 Payara Services Ltd.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -92,7 +93,7 @@ public class ClassEnhancer extends TFEnhanceAdapter {
         public InfoMethodRewriter( MethodVisitor mv,
             int acc, String name, String desc ) {
 
-            super( mv, acc, name, desc ) ;
+            super( Opcodes.ASM7, mv, acc, name, desc ) ;
             this.access = acc ;
             this.name = name ;
             this.desc = desc ;
@@ -147,7 +148,7 @@ public class ClassEnhancer extends TFEnhanceAdapter {
         public InfoMethodCallRewriter( MethodVisitor mv,
             int acc, String name, String desc ) {
 
-            super( mv, acc, name, desc ) ;
+            super( Opcodes.ASM7, mv, acc, name, desc ) ;
         }
 
         @Override
@@ -191,7 +192,7 @@ public class ClassEnhancer extends TFEnhanceAdapter {
         public NormalMethodChecker( MethodVisitor mv,
             int acc, String name, String desc ) {
 
-            super( mv, acc, name, desc ) ;
+            super( Opcodes.ASM7, mv, acc, name, desc ) ;
 
 	    mname = util.getFullMethodDescriptor(name, desc ) ;
         }

--- a/pfl-tf-tools/src/main/java/org/glassfish/pfl/tf/tools/enhancer/ClassTracer.java
+++ b/pfl-tf-tools/src/main/java/org/glassfish/pfl/tf/tools/enhancer/ClassTracer.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 Payara Services Ltd.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -275,7 +276,7 @@ public class ClassTracer extends TFEnhanceAdapter {
                 fname, Type.getDescriptor( SynchronizedHolder.class ));
             lmv.visitMethodInsn( Opcodes.INVOKEVIRTUAL,
                 EnhancedClassData.SH_NAME, "content",
-                "()Ljava/lang/Object;" );
+                "()Ljava/lang/Object;", false );
             lmv.visitTypeInsn( Opcodes.CHECKCAST,
                 EnhancedClassData.MM_NAME );
             lmv.visitVarInsn( Opcodes.ASTORE, __mm.index );
@@ -292,7 +293,7 @@ public class ClassTracer extends TFEnhanceAdapter {
 
             lmv.visitMethodInsn( Opcodes.INVOKEINTERFACE,
                 EnhancedClassData.MM_NAME, "enter",
-                "(I[Ljava/lang/Object;)V" ) ;
+                "(I[Ljava/lang/Object;)V", true ) ;
 
             // }
             lmv.visitLabel( start ) ;
@@ -310,7 +311,7 @@ public class ClassTracer extends TFEnhanceAdapter {
 
             lmv.visitMethodInsn( Opcodes.INVOKEINTERFACE,
                 EnhancedClassData.MM_NAME, "exception",
-                "(ILjava/lang/Throwable;)V" ) ;
+                "(ILjava/lang/Throwable;)V", true ) ;
 
             lmv.visitLabel( skipLabel ) ;
         }
@@ -328,14 +329,14 @@ public class ClassTracer extends TFEnhanceAdapter {
             if (rtype.equals( Type.VOID_TYPE )) {
                 lmv.visitMethodInsn( Opcodes.INVOKEINTERFACE,
                     EnhancedClassData.MM_NAME, "exit",
-                    "(I)V" ) ;
+                    "(I)V", true ) ;
             } else {
                 util.wrapArg( lmv, __result.index,
                     Type.getType( __result.desc ) ) ;
 
                 lmv.visitMethodInsn( Opcodes.INVOKEINTERFACE,
                     EnhancedClassData.MM_NAME, "exit",
-                    "(ILjava/lang/Object;)V" ) ;
+                    "(ILjava/lang/Object;)V", true ) ;
             }
 
             lmv.visitLabel( skipLabel ) ;
@@ -387,7 +388,7 @@ public class ClassTracer extends TFEnhanceAdapter {
 
         @Override
         public void visitMethodInsn( final int opcode, final String owner,
-            final String name, final String desc ) {
+            final String name, final String desc, final boolean isInterface ) {
             info( 2, "MM method: visitMethodInsn["
                 + Util.opcodeToString(opcode) + "]: " + owner
                 + "." + name + desc ) ;
@@ -408,11 +409,11 @@ public class ClassTracer extends TFEnhanceAdapter {
                 lmv.visitVarInsn( Opcodes.ALOAD, __mm.index ) ;
                 util.emitIntConstant(lmv, identVal );
 
-                lmv.visitMethodInsn(opcode, owner, name, desc );
+                lmv.visitMethodInsn(opcode, owner, name, desc, isInterface );
             } else {
                 current = current.transition( util, lmv, Input.OTHER ) ;
 
-                lmv.visitMethodInsn(opcode, owner, name, desc );
+                lmv.visitMethodInsn(opcode, owner, name, desc, isInterface );
             }
         }
 

--- a/pfl-tf-tools/src/main/java/org/glassfish/pfl/tf/tools/enhancer/SimpleMethodTracer.java
+++ b/pfl-tf-tools/src/main/java/org/glassfish/pfl/tf/tools/enhancer/SimpleMethodTracer.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 Payara Services Ltd.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -114,10 +115,10 @@ public class SimpleMethodTracer extends MethodVisitor {
         mv.visitFieldInsn(opcode, owner, name, desc);
     }
 
-    public void visitMethodInsn(int opcode, String owner, String name, String desc) {
+    public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean isInterface) {
         msg( "visitMethodInsn(opcode=" + Util.opcodeToString(opcode)
             + ",owner=" + owner + ",name=" + name + ",desc=" + desc + ")" ) ;
-        mv.visitMethodInsn(opcode, owner, name, desc);
+        mv.visitMethodInsn(opcode, owner, name, desc, isInterface);
     }
 
     public void visitJumpInsn(int opcode, Label label) {

--- a/pfl-tf-tools/src/main/java/org/glassfish/pfl/tf/tools/enhancer/StaticInitVisitor.java
+++ b/pfl-tf-tools/src/main/java/org/glassfish/pfl/tf/tools/enhancer/StaticInitVisitor.java
@@ -69,7 +69,7 @@ public class StaticInitVisitor extends LocalVariablesSorter {
                 "Ljava/io/PrintStream;" ) ;
             mv.visitLdcInsn( msg );
             mv.visitMethodInsn( Opcodes.INVOKEVIRTUAL, "java/io/PrintStream",
-                "println", "(Ljava/lang/String;)V");
+                "println", "(Ljava/lang/String;)V", false);
         }
     }
 
@@ -83,7 +83,7 @@ public class StaticInitVisitor extends LocalVariablesSorter {
 	    Type mmrType = Type.getType( MethodMonitorRegistry.class ) ;
 	    String mdesc = "(Ljava/lang/Class;)V" ;
 	    mv.visitMethodInsn( Opcodes.INVOKESTATIC,
-		mmrType.getInternalName(), "registerClass", mdesc ) ;
+		mmrType.getInternalName(), "registerClass", mdesc, false ) ;
 	} else {
 	    int line = 1 ;
 	    util.info( 2, "StaticInitVisitor.visitCode" ) ;
@@ -126,7 +126,7 @@ public class StaticInitVisitor extends LocalVariablesSorter {
 		mv.visitVarInsn( Opcodes.ALOAD, mnameList.index ) ;
 		mv.visitLdcInsn( str );
 		mv.visitMethodInsn( Opcodes.INVOKEINTERFACE,
-		    "java/util/List", "add", "(Ljava/lang/Object;)Z" );
+		    "java/util/List", "add", "(Ljava/lang/Object;)Z", true );
 		mv.visitInsn( Opcodes.POP ) ;
 	    }
 
@@ -153,7 +153,7 @@ public class StaticInitVisitor extends LocalVariablesSorter {
 
 		mv.visitMethodInsn( Opcodes.INVOKEINTERFACE,
 		    "java/util/Map", "put",
-		    "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+		    "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;", true);
 
 		mv.visitInsn( Opcodes.POP ) ;
 	    }
@@ -170,7 +170,7 @@ public class StaticInitVisitor extends LocalVariablesSorter {
 	    String mdesc =
                 "(Ljava/lang/Class;Ljava/util/List;Ljava/util/Map;)V" ;
 	    mv.visitMethodInsn( Opcodes.INVOKESTATIC,
-		mmrType.getInternalName(), "registerClass", mdesc ) ;
+		mmrType.getInternalName(), "registerClass", mdesc, false ) ;
 
 	    mv.visitLabel( end ) ;
 

--- a/pfl-tf-tools/src/main/java/org/glassfish/pfl/tf/tools/enhancer/StaticInitVisitor.java
+++ b/pfl-tf-tools/src/main/java/org/glassfish/pfl/tf/tools/enhancer/StaticInitVisitor.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 Payara Services Ltd.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -40,7 +41,7 @@ public class StaticInitVisitor extends LocalVariablesSorter {
     public StaticInitVisitor( final int access, final String desc,
         final MethodVisitor mv, Util util, EnhancedClassData ecd ) {
 
-        super( access, desc, mv ) ;
+        super( Opcodes.ASM7, access, desc, mv ) ;
         this.util = util ;
         this.ecd = ecd ;
         util.info( 2, "StaticInitVisitor created" ) ;

--- a/pfl-tf/src/main/java/org/glassfish/pfl/tf/spi/Util.java
+++ b/pfl-tf/src/main/java/org/glassfish/pfl/tf/spi/Util.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 Payara Services Ltd.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -336,8 +337,7 @@ public class Util {
 
         final ClassReader cr = new ClassReader(cls) ;
         final ClassWriter cw = new ClassWriter(
-            ClassWriter.COMPUTE_MAXS ) ;
-            // ClassWriter.COMPUTE_FRAMES + ClassWriter.COMPUTE_MAXS ) ;
+            ClassWriter.COMPUTE_FRAMES ) ;
 
         PrintWriter pw = null ;
         // TraceClassVisitor tcv = null ;

--- a/pfl-tf/src/main/java/org/glassfish/pfl/tf/spi/Util.java
+++ b/pfl-tf/src/main/java/org/glassfish/pfl/tf/spi/Util.java
@@ -123,7 +123,7 @@ public class Util {
         mv.visitTypeInsn( Opcodes.NEW, type.getInternalName() );
         mv.visitInsn( Opcodes.DUP ) ;
         mv.visitMethodInsn( Opcodes.INVOKESPECIAL,
-            type.getInternalName(), "<init>", "()V" );
+            type.getInternalName(), "<init>", "()V", false );
     }
 
     public String augmentInfoMethodDescriptor( String desc ) {
@@ -184,49 +184,49 @@ public class Util {
                 mv.visitVarInsn( Opcodes.ILOAD,  argIndex ) ;
                 mv.visitMethodInsn( Opcodes.INVOKESTATIC,
                     Type.getInternalName( Boolean.class ), "valueOf",
-                    "(Z)Ljava/lang/Boolean;" );
+                    "(Z)Ljava/lang/Boolean;", false );
                 break ;
             case Type.BYTE :
                 mv.visitVarInsn( Opcodes.ILOAD,  argIndex ) ;
                 mv.visitMethodInsn( Opcodes.INVOKESTATIC,
                     Type.getInternalName( Byte.class ), "valueOf",
-                    "(B)Ljava/lang/Byte;" );
+                    "(B)Ljava/lang/Byte;", false );
                 break ;
             case Type.CHAR :
                 mv.visitVarInsn( Opcodes.ILOAD,  argIndex ) ;
                 mv.visitMethodInsn( Opcodes.INVOKESTATIC,
                     Type.getInternalName( Character.class ), "valueOf",
-                    "(C)Ljava/lang/Character;" );
+                    "(C)Ljava/lang/Character;", false );
                 break ;
             case Type.SHORT :
                 mv.visitVarInsn( Opcodes.ILOAD,  argIndex ) ;
                 mv.visitMethodInsn( Opcodes.INVOKESTATIC,
                     Type.getInternalName( Short.class ), "valueOf",
-                    "(S)Ljava/lang/Short;" );
+                    "(S)Ljava/lang/Short;", false );
                 break ;
             case Type.INT :
                 mv.visitVarInsn( Opcodes.ILOAD,  argIndex ) ;
                 mv.visitMethodInsn( Opcodes.INVOKESTATIC,
                     Type.getInternalName( Integer.class ), "valueOf",
-                    "(I)Ljava/lang/Integer;" );
+                    "(I)Ljava/lang/Integer;", false );
                 break ;
             case Type.LONG :
                 mv.visitVarInsn( Opcodes.LLOAD,  argIndex ) ;
                 mv.visitMethodInsn( Opcodes.INVOKESTATIC,
                     Type.getInternalName( Long.class ), "valueOf",
-                    "(J)Ljava/lang/Long;" );
+                    "(J)Ljava/lang/Long;", false );
                 break ;
             case Type.DOUBLE :
                 mv.visitVarInsn( Opcodes.DLOAD,  argIndex ) ;
                 mv.visitMethodInsn( Opcodes.INVOKESTATIC,
                     Type.getInternalName( Double.class ), "valueOf",
-                    "(D)Ljava/lang/Double;" );
+                    "(D)Ljava/lang/Double;", false );
                 break ;
             case Type.FLOAT :
                 mv.visitVarInsn( Opcodes.FLOAD,  argIndex ) ;
                 mv.visitMethodInsn( Opcodes.INVOKESTATIC,
                     Type.getInternalName( Float.class ), "valueOf",
-                    "(F)Ljava/lang/Float;" );
+                    "(F)Ljava/lang/Float;", false );
                 break ;
             default :
                 mv.visitVarInsn( Opcodes.ALOAD,  argIndex ) ;


### PR DESCRIPTION
Until GlassFish 3, you could output method traces for ORB processing by specifying the annotation name with  
the `-Dcom.sun.corba.ee.ORBDebug` option, but as of GlassFish 4 the option no longer works.  
This is due to the removal of the EnhanceTool, but it could not be tracked in `javaee/glassfish-corba` commit history.  
Oldest Commit: https://github.com/javaee/glassfish-corba/blob/d407cbd53879dbdae94c76c5804d1b46386a1933/orbmain/pom.xml  
  
The method trace is very useful for tracing complex ORB operations, so I'd like to re-enable it.  
Before that, this PR will compensate for missing changes about the asm incompatibilities.  
  
After this PR is merged and released, I will also issue PR to https://github.com/eclipse-ee4j/orb.  